### PR TITLE
Mark as compatible with Gnome 41 too

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Disable all GNOME built-in gestures. Useful for kiosks and touch screen apps.",
   "uuid": "disable-gestures-2021@verycrazydog.gmail.com",
   "shell-version": [
-    "3.36", "40.0"
+    "3.36", "40", "41"
   ],
   "url": "https://github.com/VeryCrazyDog/gnome-disable-gestures"
 }


### PR DESCRIPTION
I've tested this change with Fedora 35 + Gnome 41.5 and it works fine.

Please enable it for Gnome 41, it will be very useful to my project's users [vmpk](/pedrolcl/vmpk)